### PR TITLE
Add MCP server for Claude Code integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,12 @@
-.PHONY: local.dev local.build local.install local.clean local.link local.test
+.PHONY: local.dev local.mcp local.build local.install local.clean local.link local.test
 
 # Run the TUI in development mode
 local.dev:
 	npm run dev
+
+# Run the MCP server in development mode
+local.mcp:
+	npm run dev:mcp
 
 # Build TypeScript to dist/
 local.build:

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ A no-nonsense TUI for managing local development projects. Built with React and 
 - **GitHub integration** - View issues and PRs, open in browser
 - **Makefile detection** - Auto-discovers `local.*` targets
 - **Responsive layout** - Grid view on large terminals, list view on small
+- **MCP Server** - Control Swanson from Claude Code via natural language
 
 ## Installation
 
@@ -88,7 +89,45 @@ Swanson checks for these tools at startup:
 | `make local.install` | Install npm dependencies |
 | `make local.clean` | Remove dist/ and node_modules/ |
 | `make local.link` | Build and link globally |
+| `make local.mcp` | Run MCP server in development mode |
 | `make local.test` | Run tests |
+
+## Claude Code Integration (MCP)
+
+Swanson includes an MCP server for Claude Code integration. This lets you manage projects through natural conversation:
+
+```
+You: "Start the dev server for funeralsni"
+You: "Show me the logs"
+You: "What GitHub issues are open?"
+You: "Stop all running processes"
+```
+
+### Setup
+
+```bash
+# Build and link
+make local.link
+
+# Register with Claude Code
+claude mcp add --transport stdio swanson -- swanson-mcp
+
+# Restart Claude Code
+```
+
+### Available Tools
+
+| Tool | Description |
+|------|-------------|
+| `swanson_list_projects` | List all projects |
+| `swanson_start_process` | Start a make target |
+| `swanson_stop_process` | Stop a process |
+| `swanson_get_logs` | Get process logs |
+| `swanson_gh_issues` | List GitHub issues |
+| `swanson_gh_prs` | List pull requests |
+| `swanson_git_status` | Get git status |
+
+See [docs/MCP_SERVER.md](docs/MCP_SERVER.md) for full documentation.
 
 ## Project Structure
 
@@ -100,6 +139,8 @@ swanson/
 │   └── swanson_projects.png
 ├── bin/
 │   └── swanson.js
+├── docs/
+│   └── MCP_SERVER.md
 ├── src/
 │   ├── index.tsx
 │   ├── app.tsx
@@ -111,14 +152,22 @@ swanson/
 │   │   └── LogViewer.tsx
 │   ├── hooks/
 │   │   └── useTerminalSize.ts
-│   └── lib/
-│       ├── github.ts
-│       ├── git.ts
-│       ├── lazygit.ts
-│       ├── makefile.ts
-│       ├── prerequisites.ts
-│       ├── process.ts
-│       └── projects.ts
+│   ├── lib/
+│   │   ├── github.ts
+│   │   ├── git.ts
+│   │   ├── lazygit.ts
+│   │   ├── makefile.ts
+│   │   ├── prerequisites.ts
+│   │   ├── process.ts
+│   │   └── projects.ts
+│   └── mcp/
+│       ├── index.ts
+│       ├── server.ts
+│       └── tools/
+│           ├── projects.ts
+│           ├── process.ts
+│           ├── github.ts
+│           └── git.ts
 ├── Makefile
 ├── package.json
 └── tsconfig.json

--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -1,0 +1,561 @@
+# Swanson MCP Server
+
+The Swanson MCP (Model Context Protocol) server allows you to manage your development projects directly from Claude Code. Start dev servers, check logs, view GitHub issues, and more - all through natural conversation.
+
+## Installation
+
+### Prerequisites
+
+- Node.js 18+
+- Claude Code CLI installed
+- Swanson built and linked globally
+
+### Setup
+
+1. **Build and link Swanson**:
+   ```bash
+   cd /path/to/swanson
+   make local.link
+   ```
+
+2. **Register with Claude Code**:
+   ```bash
+   claude mcp add --transport stdio swanson -- swanson-mcp
+   ```
+
+3. **Verify installation**:
+   ```bash
+   claude mcp list
+   ```
+   You should see `swanson` in the list.
+
+4. **Restart Claude Code** to load the new MCP server.
+
+### Alternative: Development Mode
+
+For testing without linking globally:
+```bash
+claude mcp add --transport stdio swanson -- node /Users/swm/Code/swanson/dist/mcp/index.js
+```
+
+---
+
+## Available Tools
+
+### Project Management
+
+#### `swanson_list_projects`
+List all configured development projects.
+
+**Parameters:** None
+
+**Example prompts:**
+- "What projects do I have configured?"
+- "List all my projects"
+- "Show me the Swanson projects"
+
+**Response:**
+```json
+[
+  {
+    "name": "funeralsni",
+    "path": "/Users/swm/Code/funeralsni",
+    "icon": "⚱️",
+    "color": "red",
+    "description": "Funeral notices NI"
+  },
+  ...
+]
+```
+
+---
+
+#### `swanson_get_project`
+Get details for a specific project.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `name` | string | Yes | Project name (e.g., 'funeralsni', 'jotter') |
+
+**Example prompts:**
+- "Tell me about the jotter project"
+- "Get details for funeralsni"
+- "What's the path for swanson?"
+
+---
+
+#### `swanson_list_targets`
+List available make targets (local.*) for a project.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `projectName` | string | Yes | Project name |
+
+**Example prompts:**
+- "What make targets does funeralsni have?"
+- "List the available commands for jotter"
+- "What can I run in swanson?"
+
+**Response:**
+```json
+[
+  {
+    "name": "local.dev",
+    "description": "Run the TUI in development mode",
+    "phony": true
+  },
+  {
+    "name": "local.build",
+    "description": "Build TypeScript to dist/",
+    "phony": true
+  }
+]
+```
+
+---
+
+### Process Management
+
+#### `swanson_start_process`
+Start a make target as a background process.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `projectName` | string | Yes | Project name |
+| `target` | string | Yes | Make target (e.g., 'local.dev') |
+
+**Example prompts:**
+- "Start the dev server for funeralsni"
+- "Run local.dev for jotter"
+- "Start whatisonthe.tv in development mode"
+
+**Response:**
+```json
+{
+  "id": "funeralsni:local.dev",
+  "name": "local.dev",
+  "command": "make local.dev",
+  "cwd": "/Users/swm/Code/funeralsni",
+  "status": "running",
+  "pid": 12345,
+  "logCount": 15
+}
+```
+
+**Notes:**
+- The process runs in the background and persists between tool calls
+- Use `swanson_get_logs` to see output
+- Use `swanson_stop_process` to stop it
+
+---
+
+#### `swanson_stop_process`
+Stop a running process.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `processId` | string | Yes | Process ID (format: 'projectName:target') |
+
+**Example prompts:**
+- "Stop the funeralsni dev server"
+- "Kill the process for jotter:local.dev"
+- "Stop funeralsni:local.dev"
+
+---
+
+#### `swanson_stop_all`
+Stop all running processes.
+
+**Parameters:** None
+
+**Example prompts:**
+- "Stop all running processes"
+- "Kill everything"
+- "Shut down all dev servers"
+
+---
+
+#### `swanson_list_processes`
+List all running and tracked processes.
+
+**Parameters:** None
+
+**Example prompts:**
+- "What's currently running?"
+- "Show me all processes"
+- "List active dev servers"
+
+**Response:**
+```json
+[
+  {
+    "id": "funeralsni:local.dev",
+    "name": "local.dev",
+    "status": "running",
+    "pid": 12345,
+    "logCount": 150
+  },
+  {
+    "id": "jotter:local.dev",
+    "name": "local.dev",
+    "status": "stopped",
+    "logCount": 45
+  }
+]
+```
+
+---
+
+#### `swanson_get_process`
+Get status of a specific process.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `processId` | string | Yes | Process ID (format: 'projectName:target') |
+
+**Example prompts:**
+- "Is funeralsni still running?"
+- "Check the status of jotter:local.dev"
+- "What's the state of the funeralsni process?"
+
+---
+
+#### `swanson_get_logs`
+Get logs for a process.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `processId` | string | Yes | Process ID (format: 'projectName:target') |
+| `lines` | number | No | Number of lines to return (default: 500, max: 500) |
+
+**Example prompts:**
+- "Show me the logs for funeralsni"
+- "Get the last 50 lines from jotter:local.dev"
+- "What's the output from the dev server?"
+
+**Notes:**
+- Logs include both stdout and stderr
+- Stderr lines are prefixed with `[stderr]`
+- Logs persist even after a process stops (until the MCP server restarts)
+
+---
+
+### GitHub Integration
+
+#### `swanson_gh_status`
+Check if GitHub CLI is installed and authenticated for a project.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `projectName` | string | Yes | Project name |
+
+**Example prompts:**
+- "Is GitHub configured for funeralsni?"
+- "Check GitHub authentication for jotter"
+
+---
+
+#### `swanson_gh_issues`
+List GitHub issues for a project.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `projectName` | string | Yes | Project name |
+| `state` | string | No | Filter: 'open', 'closed', or 'all' (default: 'open') |
+| `limit` | number | No | Max issues to return (default: 30) |
+
+**Example prompts:**
+- "What GitHub issues are open for funeralsni?"
+- "Show me all issues for jotter"
+- "List the last 10 closed issues for swanson"
+
+**Response:**
+```json
+[
+  {
+    "number": 1,
+    "title": "Add MCP server for Claude integration",
+    "state": "open",
+    "createdAt": "2024-01-15T10:30:00Z",
+    "author": "swmcc",
+    "labels": ["enhancement"],
+    "commentsCount": 2,
+    "url": "https://github.com/swmcc/swanson/issues/1"
+  }
+]
+```
+
+---
+
+#### `swanson_gh_issue`
+Get detailed information about a specific issue.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `projectName` | string | Yes | Project name |
+| `issueNumber` | number | Yes | Issue number |
+
+**Example prompts:**
+- "Show me issue #1 for swanson"
+- "Get details on funeralsni issue 42"
+- "What's in jotter issue number 5?"
+
+**Response includes:**
+- Full issue body/description
+- All comments with authors and timestamps
+- Assignees and milestone
+- Labels
+
+---
+
+#### `swanson_gh_prs`
+List GitHub pull requests for a project.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `projectName` | string | Yes | Project name |
+| `state` | string | No | Filter: 'open', 'closed', or 'all' (default: 'open') |
+| `limit` | number | No | Max PRs to return (default: 30) |
+
+**Example prompts:**
+- "What PRs are open for funeralsni?"
+- "Show me pull requests for jotter"
+- "List merged PRs for swanson"
+
+**Response:**
+```json
+[
+  {
+    "number": 2,
+    "title": "Add dark mode support",
+    "state": "open",
+    "author": "swmcc",
+    "headBranch": "feature/dark-mode",
+    "baseBranch": "main",
+    "isDraft": false,
+    "reviewDecision": "APPROVED",
+    "url": "https://github.com/swmcc/project/pull/2"
+  }
+]
+```
+
+---
+
+#### `swanson_gh_stats`
+Get quick GitHub stats (open issues and PRs count).
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `projectName` | string | Yes | Project name |
+
+**Example prompts:**
+- "How many open issues does funeralsni have?"
+- "Give me a quick GitHub summary for jotter"
+- "What's the issue/PR count for swanson?"
+
+**Response:**
+```json
+{
+  "openIssues": 5,
+  "openPRs": 2
+}
+```
+
+---
+
+### Git Integration
+
+#### `swanson_git_status`
+Get git status for a project.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `projectName` | string | Yes | Project name |
+
+**Example prompts:**
+- "What's the git status for funeralsni?"
+- "Is jotter clean?"
+- "What branch is swanson on?"
+
+**Response:**
+```json
+{
+  "branch": "main",
+  "isClean": false,
+  "ahead": 2,
+  "behind": 0,
+  "staged": 1,
+  "unstaged": 3,
+  "untracked": 2
+}
+```
+
+---
+
+#### `swanson_git_pull`
+Pull latest changes for a project.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `projectName` | string | Yes | Project name |
+
+**Example prompts:**
+- "Pull the latest for funeralsni"
+- "Update jotter from remote"
+- "Git pull swanson"
+
+---
+
+#### `swanson_git_fetch`
+Fetch from remote without merging.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `projectName` | string | Yes | Project name |
+
+**Example prompts:**
+- "Fetch updates for funeralsni"
+- "Check if jotter has remote changes"
+
+---
+
+## Example Workflows
+
+### Starting a Development Session
+
+```
+You: "What projects do I have?"
+Claude: [Lists all 10 projects with descriptions]
+
+You: "Start the dev server for funeralsni"
+Claude: [Starts local.dev, reports PID and status]
+
+You: "Show me the logs"
+Claude: [Displays recent output from the server]
+
+You: "What GitHub issues are open for it?"
+Claude: [Lists open issues with titles and authors]
+```
+
+### Checking Project Status
+
+```
+You: "Give me a status report on jotter"
+Claude: [Calls swanson_git_status, swanson_gh_stats]
+"Jotter is on branch 'main', 2 commits ahead of remote.
+There are 3 open issues and 1 open PR."
+
+You: "What are those issues?"
+Claude: [Calls swanson_gh_issues]
+[Lists the 3 open issues]
+```
+
+### Managing Multiple Services
+
+```
+You: "Start dev servers for funeralsni and jotter"
+Claude: [Starts both processes]
+
+You: "What's running?"
+Claude: [Lists both running processes with PIDs]
+
+You: "Stop everything"
+Claude: [Stops all processes]
+```
+
+### Debugging
+
+```
+You: "Start funeralsni and show me if there are any errors"
+Claude: [Starts process, waits, checks logs for errors]
+
+You: "Show me the last 100 lines of logs"
+Claude: [Displays recent log output]
+
+You: "Is it still running?"
+Claude: [Checks process status]
+```
+
+---
+
+## Troubleshooting
+
+### MCP Server Not Found
+
+```bash
+# Check if swanson-mcp is in PATH
+which swanson-mcp
+
+# If not, rebuild and relink
+cd /path/to/swanson
+make local.link
+```
+
+### Tools Not Appearing
+
+1. Restart Claude Code after adding the MCP server
+2. Check the server is registered: `claude mcp list`
+3. Test manually:
+   ```bash
+   echo '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' | swanson-mcp
+   ```
+
+### Process Won't Start
+
+- Check the project has a Makefile with `local.*` targets
+- Verify the project path exists
+- Check for errors in the logs: `swanson_get_logs`
+
+### GitHub Tools Failing
+
+- Ensure `gh` CLI is installed: `gh --version`
+- Authenticate: `gh auth login`
+- Check the project is a GitHub repo: `gh repo view`
+
+---
+
+## Architecture
+
+The MCP server reuses Swanson's existing library modules:
+
+```
+src/mcp/
+├── index.ts        # Entry point, STDIO transport
+├── server.ts       # Tool registration
+└── tools/
+    ├── projects.ts # Wraps lib/projects.ts
+    ├── process.ts  # Wraps lib/process.ts (singleton)
+    ├── github.ts   # Wraps lib/github.ts
+    └── git.ts      # Wraps lib/git.ts
+```
+
+The `processManager` singleton maintains state between tool calls, so processes started via `swanson_start_process` persist until stopped or the MCP server exits.
+
+---
+
+## Configuration
+
+The MCP server uses the same project configuration as the TUI. Projects are defined in `src/lib/projects.ts`. To add a new project, edit that file and rebuild.
+
+---
+
+## Limitations
+
+- **No real-time log streaming**: Logs are fetched on-demand, not pushed
+- **Single user**: The MCP server is designed for local, single-user use
+- **Process state**: State is lost if the MCP server restarts
+- **No Windows support**: Paths and process management are Unix-focused

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "swanson",
       "version": "0.1.0",
       "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.26.0",
         "chalk": "^5.3.0",
         "figlet": "^1.7.0",
         "ink": "^5.0.1",
@@ -16,6 +17,7 @@
         "ink-spinner": "^5.0.0",
         "react": "^18.3.1",
         "terminal-image": "^3.0.0",
+        "zod": "^4.3.6",
         "zustand": "^4.5.2"
       },
       "bin": {
@@ -493,6 +495,18 @@
         "node": ">=18"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.9",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
+      "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@jimp/core": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@jimp/core/-/core-1.6.0.tgz",
@@ -714,6 +728,15 @@
         "node": ">=18"
       }
     },
+    "node_modules/@jimp/plugin-blit/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/@jimp/plugin-blur": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@jimp/plugin-blur/-/plugin-blur-1.6.0.tgz",
@@ -740,6 +763,15 @@
         "node": ">=18"
       }
     },
+    "node_modules/@jimp/plugin-circle/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/@jimp/plugin-color": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-1.6.0.tgz",
@@ -754,6 +786,15 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-color/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@jimp/plugin-contain": {
@@ -773,6 +814,15 @@
         "node": ">=18"
       }
     },
+    "node_modules/@jimp/plugin-contain/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/@jimp/plugin-cover": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@jimp/plugin-cover/-/plugin-cover-1.6.0.tgz",
@@ -787,6 +837,15 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-cover/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@jimp/plugin-crop": {
@@ -804,6 +863,15 @@
         "node": ">=18"
       }
     },
+    "node_modules/@jimp/plugin-crop/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/@jimp/plugin-displace": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@jimp/plugin-displace/-/plugin-displace-1.6.0.tgz",
@@ -816,6 +884,15 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-displace/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@jimp/plugin-dither": {
@@ -844,6 +921,15 @@
         "node": ">=18"
       }
     },
+    "node_modules/@jimp/plugin-fisheye/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/@jimp/plugin-flip": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@jimp/plugin-flip/-/plugin-flip-1.6.0.tgz",
@@ -855,6 +941,15 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-flip/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@jimp/plugin-gaussian": {
@@ -937,6 +1032,15 @@
         "node": ">=18"
       }
     },
+    "node_modules/@jimp/plugin-mask/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/@jimp/plugin-normalize": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@jimp/plugin-normalize/-/plugin-normalize-0.14.0.tgz",
@@ -981,6 +1085,15 @@
         "node": ">=18"
       }
     },
+    "node_modules/@jimp/plugin-print/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/@jimp/plugin-quantize": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@jimp/plugin-quantize/-/plugin-quantize-1.6.0.tgz",
@@ -992,6 +1105,15 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-quantize/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@jimp/plugin-resize": {
@@ -1006,6 +1128,15 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-resize/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@jimp/plugin-rotate": {
@@ -1023,6 +1154,15 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-rotate/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@jimp/plugin-scale": {
@@ -1089,6 +1229,15 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-threshold/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@jimp/plugins": {
@@ -1370,6 +1519,15 @@
         "node": ">=18"
       }
     },
+    "node_modules/@jimp/types/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/@jimp/utils": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-1.6.0.tgz",
@@ -1381,6 +1539,46 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.26.0.tgz",
+      "integrity": "sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
       }
     },
     "node_modules/@tokenizer/token": {
@@ -1458,6 +1656,52 @@
       },
       "engines": {
         "node": ">=6.5"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/ansi-escapes": {
@@ -1579,6 +1823,30 @@
       "integrity": "sha512-cTEHk2jLrPyi+12M3dhpEbnnPOsaZuq7C45ylbbQIiWgDFZq4UVYPEY5mlqjvsj/6gJv9qX5sa+ebDzLXT28Vw==",
       "license": "MIT"
     },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/buffer": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
@@ -1610,6 +1878,44 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/centra": {
@@ -1759,6 +2065,28 @@
         "node": ">=20"
       }
     },
+    "node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/convert-to-spaces": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/convert-to-spaces/-/convert-to-spaces-2.0.1.tgz",
@@ -1766,6 +2094,41 @@
       "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/cross-spawn": {
@@ -1799,6 +2162,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/decode-gif": {
@@ -1838,16 +2218,54 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/dom-walk": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
       "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
     },
     "node_modules/emoji-regex": {
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/environment": {
       "version": "1.1.0",
@@ -1859,6 +2277,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/es-toolkit": {
@@ -1913,6 +2361,12 @@
         "@esbuild/win32-x64": "0.27.3"
       }
     },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
     "node_modules/escape-string-regexp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
@@ -1920,6 +2374,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/event-target-shim": {
@@ -1938,6 +2401,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.x"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/execa": {
@@ -1967,6 +2451,89 @@
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/exif-parser/-/exif-parser-0.1.12.tgz",
       "integrity": "sha512-c2bQfLNbMzLPmzQuOr8fy0csy84WmwnER81W88DzTp9CYNPJ6yzOj2EZAh9pywYpqHnshVLHQJ8WzldAyfY+Iw=="
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.2.1.tgz",
+      "integrity": "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.0.1"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/figlet": {
       "version": "1.10.0",
@@ -2000,6 +2567,27 @@
         "url": "https://github.com/sindresorhus/file-type?sponsor=1"
       }
     },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/follow-redirects": {
       "version": "1.15.11",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
@@ -2018,6 +2606,24 @@
         "debug": {
           "optional": true
         }
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/fsevents": {
@@ -2054,6 +2660,43 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-stream": {
@@ -2099,6 +2742,18 @@
       "dependencies": {
         "min-document": "^2.19.0",
         "process": "^0.11.10"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/gradient-string": {
@@ -2166,6 +2821,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -2178,6 +2845,35 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hono": {
+      "version": "4.11.8",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.8.tgz",
+      "integrity": "sha512-eVkB/CYCCei7K2WElZW9yYQFWssG0DhaDhVvr7wy5jJ22K+ck8fWW0EsLpB0sITUTvPnc97+rrbQqIr5iqiy9Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/human-signals": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
@@ -2185,6 +2881,22 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/ieee754": {
@@ -2248,6 +2960,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
     },
     "node_modules/ink": {
       "version": "5.2.1",
@@ -2354,6 +3072,24 @@
         "react": ">=18.0.0"
       }
     },
+    "node_modules/ip-address": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/is-accessor-descriptor": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.1.tgz",
@@ -2442,6 +3178,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
     "node_modules/is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -2514,6 +3256,15 @@
         "node": ">=18"
       }
     },
+    "node_modules/jose": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
+      "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/jpeg-js": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz",
@@ -2525,6 +3276,18 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/kind-of": {
       "version": "3.2.2",
@@ -2668,6 +3431,36 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -2684,6 +3477,31 @@
       },
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/mimic-fn": {
@@ -2737,6 +3555,21 @@
         "mkdirp": "bin/cmd.js"
       }
     },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/npm-run-path": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
@@ -2758,11 +3591,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/omggif": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/omggif/-/omggif-1.0.10.tgz",
       "integrity": "sha512-LMJTtvgc/nugXj0Vcrrs68Mn2D1r0zf630VNtqtpI1FEO7e+O9FP4gqs9AcnBaSEeoHIPm28u6qgPR0oyEpGSw==",
       "license": "MIT"
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
     },
     "node_modules/onetime": {
       "version": "5.1.2",
@@ -2813,6 +3679,15 @@
       "integrity": "sha512-Tz11t3uKztEW5FEVZnj1ox8GKblWn+PvHY9TmJV5Mll2uHEwRdR/5Li1OlXoECjLYkApdhWy44ocONwXLiKO5A==",
       "license": "MIT"
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/patch-console": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/patch-console/-/patch-console-2.0.0.tgz",
@@ -2829,6 +3704,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/peek-readable": {
@@ -2872,6 +3757,15 @@
         "node": ">=12.13.0"
       }
     },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
     "node_modules/plist": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.0.tgz",
@@ -2913,6 +3807,58 @@
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
+      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/react": {
@@ -3132,6 +4078,15 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
@@ -3158,6 +4113,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -3178,6 +4149,12 @@
       ],
       "license": "MIT"
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
     "node_modules/sax": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.4.tgz",
@@ -3195,6 +4172,57 @@
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -3215,6 +4243,78 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/signal-exit": {
@@ -3273,6 +4373,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/string_decoder": {
@@ -3415,6 +4524,15 @@
         "tinycolor2": "^1.0.0"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/token-types": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/token-types/-/token-types-4.2.1.tgz",
@@ -3464,6 +4582,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -3484,6 +4616,15 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/use-sync-external-store": {
       "version": "1.6.0",
@@ -3510,6 +4651,15 @@
       "license": "MIT",
       "dependencies": {
         "pako": "^1.0.11"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/which": {
@@ -3574,6 +4724,12 @@
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
     },
     "node_modules/ws": {
       "version": "8.19.0",
@@ -3661,12 +4817,21 @@
       "license": "MIT"
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
+      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25 || ^4"
       }
     },
     "node_modules/zustand": {

--- a/package.json
+++ b/package.json
@@ -4,22 +4,27 @@
   "description": "A no-nonsense TUI for managing local development services",
   "type": "module",
   "bin": {
-    "swanson": "./bin/swanson.js"
+    "swanson": "./bin/swanson.js",
+    "swanson-mcp": "./dist/mcp/index.js"
   },
   "scripts": {
     "dev": "tsx src/index.tsx",
+    "dev:mcp": "tsx src/mcp/index.ts",
     "build": "tsc",
-    "start": "node dist/index.js"
+    "start": "node dist/index.js",
+    "start:mcp": "node dist/mcp/index.js"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.26.0",
+    "chalk": "^5.3.0",
+    "figlet": "^1.7.0",
     "ink": "^5.0.1",
+    "ink-big-text": "^2.0.0",
     "ink-gradient": "^3.0.0",
     "ink-spinner": "^5.0.0",
-    "ink-big-text": "^2.0.0",
     "react": "^18.3.1",
     "terminal-image": "^3.0.0",
-    "figlet": "^1.7.0",
-    "chalk": "^5.3.0",
+    "zod": "^4.3.6",
     "zustand": "^4.5.2"
   },
   "devDependencies": {

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { registerAllTools } from "./server.js";
+
+const server = new McpServer({
+  name: "swanson",
+  version: "0.1.0",
+});
+
+registerAllTools(server);
+
+const transport = new StdioServerTransport();
+await server.connect(transport);
+
+// Log to stderr (never stdout - that's for MCP protocol)
+console.error("[swanson-mcp] Server started");

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,0 +1,12 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerProjectTools } from "./tools/projects.js";
+import { registerProcessTools } from "./tools/process.js";
+import { registerGitHubTools } from "./tools/github.js";
+import { registerGitTools } from "./tools/git.js";
+
+export function registerAllTools(server: McpServer): void {
+  registerProjectTools(server);
+  registerProcessTools(server);
+  registerGitHubTools(server);
+  registerGitTools(server);
+}

--- a/src/mcp/tools/git.ts
+++ b/src/mcp/tools/git.ts
@@ -1,0 +1,108 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { getGitStatus, gitPull, gitFetch } from "../../lib/git.js";
+import { getProjectConfig } from "../../lib/projects.js";
+
+export function registerGitTools(server: McpServer): void {
+  // Get git status
+  server.tool(
+    "swanson_git_status",
+    "Get git status for a project (branch, changes, ahead/behind)",
+    {
+      projectName: z.string().describe("Project name"),
+    },
+    async ({ projectName }) => {
+      const project = getProjectConfig(projectName);
+      if (!project) {
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify({ error: `Project '${projectName}' not found` }),
+          }],
+          isError: true,
+        };
+      }
+
+      const status = await getGitStatus(project.path);
+
+      if (!status) {
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify({ error: "Not a git repository or git error" }),
+          }],
+          isError: true,
+        };
+      }
+
+      return {
+        content: [{
+          type: "text",
+          text: JSON.stringify(status, null, 2),
+        }],
+      };
+    }
+  );
+
+  // Git pull
+  server.tool(
+    "swanson_git_pull",
+    "Pull latest changes for a project",
+    {
+      projectName: z.string().describe("Project name"),
+    },
+    async ({ projectName }) => {
+      const project = getProjectConfig(projectName);
+      if (!project) {
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify({ error: `Project '${projectName}' not found` }),
+          }],
+          isError: true,
+        };
+      }
+
+      const result = await gitPull(project.path);
+
+      return {
+        content: [{
+          type: "text",
+          text: JSON.stringify(result, null, 2),
+        }],
+        isError: !result.success,
+      };
+    }
+  );
+
+  // Git fetch
+  server.tool(
+    "swanson_git_fetch",
+    "Fetch from remote for a project",
+    {
+      projectName: z.string().describe("Project name"),
+    },
+    async ({ projectName }) => {
+      const project = getProjectConfig(projectName);
+      if (!project) {
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify({ error: `Project '${projectName}' not found` }),
+          }],
+          isError: true,
+        };
+      }
+
+      const result = await gitFetch(project.path);
+
+      return {
+        content: [{
+          type: "text",
+          text: JSON.stringify(result, null, 2),
+        }],
+        isError: !result.success,
+      };
+    }
+  );
+}

--- a/src/mcp/tools/github.ts
+++ b/src/mcp/tools/github.ts
@@ -1,0 +1,206 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { GitHub } from "../../lib/github.js";
+import { getProjectConfig } from "../../lib/projects.js";
+
+export function registerGitHubTools(server: McpServer): void {
+  // Check GitHub CLI status
+  server.tool(
+    "swanson_gh_status",
+    "Check GitHub CLI status for a project (installed, authenticated)",
+    {
+      projectName: z.string().describe("Project name"),
+    },
+    async ({ projectName }) => {
+      const project = getProjectConfig(projectName);
+      if (!project) {
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify({ error: `Project '${projectName}' not found` }),
+          }],
+          isError: true,
+        };
+      }
+
+      const github = new GitHub(project.path);
+      const result = await github.checkStatus();
+
+      return {
+        content: [{
+          type: "text",
+          text: JSON.stringify(result, null, 2),
+        }],
+      };
+    }
+  );
+
+  // List issues
+  server.tool(
+    "swanson_gh_issues",
+    "List GitHub issues for a project",
+    {
+      projectName: z.string().describe("Project name"),
+      state: z.enum(["open", "closed", "all"]).optional().describe("Issue state filter (default: open)"),
+      limit: z.number().optional().describe("Max issues to return (default: 30)"),
+    },
+    async ({ projectName, state = "open", limit = 30 }) => {
+      const project = getProjectConfig(projectName);
+      if (!project) {
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify({ error: `Project '${projectName}' not found` }),
+          }],
+          isError: true,
+        };
+      }
+
+      const github = new GitHub(project.path);
+      const result = await github.listIssues(state, limit);
+
+      if (!result.success) {
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify({ error: result.error }),
+          }],
+          isError: true,
+        };
+      }
+
+      return {
+        content: [{
+          type: "text",
+          text: JSON.stringify(result.data, null, 2),
+        }],
+      };
+    }
+  );
+
+  // Get issue details
+  server.tool(
+    "swanson_gh_issue",
+    "Get detailed information about a specific GitHub issue",
+    {
+      projectName: z.string().describe("Project name"),
+      issueNumber: z.number().describe("Issue number"),
+    },
+    async ({ projectName, issueNumber }) => {
+      const project = getProjectConfig(projectName);
+      if (!project) {
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify({ error: `Project '${projectName}' not found` }),
+          }],
+          isError: true,
+        };
+      }
+
+      const github = new GitHub(project.path);
+      const result = await github.getIssue(issueNumber);
+
+      if (!result.success) {
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify({ error: result.error }),
+          }],
+          isError: true,
+        };
+      }
+
+      return {
+        content: [{
+          type: "text",
+          text: JSON.stringify(result.data, null, 2),
+        }],
+      };
+    }
+  );
+
+  // List PRs
+  server.tool(
+    "swanson_gh_prs",
+    "List GitHub pull requests for a project",
+    {
+      projectName: z.string().describe("Project name"),
+      state: z.enum(["open", "closed", "all"]).optional().describe("PR state filter (default: open)"),
+      limit: z.number().optional().describe("Max PRs to return (default: 30)"),
+    },
+    async ({ projectName, state = "open", limit = 30 }) => {
+      const project = getProjectConfig(projectName);
+      if (!project) {
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify({ error: `Project '${projectName}' not found` }),
+          }],
+          isError: true,
+        };
+      }
+
+      const github = new GitHub(project.path);
+      const result = await github.listPRs(state, limit);
+
+      if (!result.success) {
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify({ error: result.error }),
+          }],
+          isError: true,
+        };
+      }
+
+      return {
+        content: [{
+          type: "text",
+          text: JSON.stringify(result.data, null, 2),
+        }],
+      };
+    }
+  );
+
+  // Quick stats
+  server.tool(
+    "swanson_gh_stats",
+    "Get quick GitHub stats (open issues and PRs) for a project",
+    {
+      projectName: z.string().describe("Project name"),
+    },
+    async ({ projectName }) => {
+      const project = getProjectConfig(projectName);
+      if (!project) {
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify({ error: `Project '${projectName}' not found` }),
+          }],
+          isError: true,
+        };
+      }
+
+      const github = new GitHub(project.path);
+      const result = await github.getQuickStats();
+
+      if (!result.success) {
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify({ error: result.error }),
+          }],
+          isError: true,
+        };
+      }
+
+      return {
+        content: [{
+          type: "text",
+          text: JSON.stringify(result.data, null, 2),
+        }],
+      };
+    }
+  );
+}

--- a/src/mcp/tools/process.ts
+++ b/src/mcp/tools/process.ts
@@ -1,0 +1,173 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { processManager, ServiceProcess } from "../../lib/process.js";
+import { getProjectConfig } from "../../lib/projects.js";
+
+// Serialize ServiceProcess for JSON output (exclude ChildProcess handle)
+function serializeProcess(p: ServiceProcess) {
+  return {
+    id: p.id,
+    name: p.name,
+    command: p.command,
+    cwd: p.cwd,
+    status: p.status,
+    pid: p.pid,
+    error: p.error,
+    logCount: p.logs.length,
+  };
+}
+
+export function registerProcessTools(server: McpServer): void {
+  // List all processes
+  server.tool(
+    "swanson_list_processes",
+    "List all running and tracked processes",
+    {},
+    async () => {
+      const processes = processManager.getAllServices().map(serializeProcess);
+      return {
+        content: [{
+          type: "text",
+          text: JSON.stringify(processes, null, 2),
+        }],
+      };
+    }
+  );
+
+  // Get specific process
+  server.tool(
+    "swanson_get_process",
+    "Get status of a specific process",
+    {
+      processId: z.string().describe("Process ID (format: 'projectName:target')"),
+    },
+    async ({ processId }) => {
+      const service = processManager.getService(processId);
+      if (!service) {
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify({ error: `Process '${processId}' not found` }),
+          }],
+          isError: true,
+        };
+      }
+      return {
+        content: [{
+          type: "text",
+          text: JSON.stringify(serializeProcess(service), null, 2),
+        }],
+      };
+    }
+  );
+
+  // Start a process
+  server.tool(
+    "swanson_start_process",
+    "Start a make target as a background process for a project",
+    {
+      projectName: z.string().describe("Project name"),
+      target: z.string().describe("Make target (e.g., 'local.dev')"),
+    },
+    async ({ projectName, target }) => {
+      const project = getProjectConfig(projectName);
+      if (!project) {
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify({ error: `Project '${projectName}' not found` }),
+          }],
+          isError: true,
+        };
+      }
+
+      const processId = `${projectName}:${target}`;
+      const service = await processManager.start(processId, target, `make ${target}`, project.path);
+
+      return {
+        content: [{
+          type: "text",
+          text: JSON.stringify(serializeProcess(service), null, 2),
+        }],
+      };
+    }
+  );
+
+  // Stop a process
+  server.tool(
+    "swanson_stop_process",
+    "Stop a running process",
+    {
+      processId: z.string().describe("Process ID (format: 'projectName:target')"),
+    },
+    async ({ processId }) => {
+      const service = processManager.getService(processId);
+      if (!service) {
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify({ error: `Process '${processId}' not found` }),
+          }],
+          isError: true,
+        };
+      }
+
+      await processManager.stop(processId);
+
+      return {
+        content: [{
+          type: "text",
+          text: JSON.stringify({ success: true, message: `Process '${processId}' stopped` }),
+        }],
+      };
+    }
+  );
+
+  // Stop all processes
+  server.tool(
+    "swanson_stop_all",
+    "Stop all running processes",
+    {},
+    async () => {
+      await processManager.stopAll();
+      return {
+        content: [{
+          type: "text",
+          text: JSON.stringify({ success: true, message: "All processes stopped" }),
+        }],
+      };
+    }
+  );
+
+  // Get logs
+  server.tool(
+    "swanson_get_logs",
+    "Get logs for a process",
+    {
+      processId: z.string().describe("Process ID (format: 'projectName:target')"),
+      lines: z.number().optional().describe("Number of lines to return (default: all, max: 500)"),
+    },
+    async ({ processId, lines }) => {
+      const service = processManager.getService(processId);
+      if (!service) {
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify({ error: `Process '${processId}' not found` }),
+          }],
+          isError: true,
+        };
+      }
+
+      const limit = lines ? Math.min(lines, 500) : 500;
+      const logs = processManager.getLogs(processId, limit);
+
+      return {
+        content: [{
+          type: "text",
+          text: logs.length > 0 ? logs.join("\n") : "(no logs)",
+        }],
+      };
+    }
+  );
+}

--- a/src/mcp/tools/projects.ts
+++ b/src/mcp/tools/projects.ts
@@ -1,0 +1,77 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { PROJECTS, getProjectConfig } from "../../lib/projects.js";
+import { parseMakefile } from "../../lib/makefile.js";
+
+export function registerProjectTools(server: McpServer): void {
+  // List all projects
+  server.tool(
+    "swanson_list_projects",
+    "List all configured development projects in Swanson",
+    {},
+    async () => {
+      return {
+        content: [{
+          type: "text",
+          text: JSON.stringify(PROJECTS, null, 2),
+        }],
+      };
+    }
+  );
+
+  // Get specific project
+  server.tool(
+    "swanson_get_project",
+    "Get details for a specific project by name",
+    {
+      name: z.string().describe("Project name (e.g., 'funeralsni', 'jotter')"),
+    },
+    async ({ name }) => {
+      const project = getProjectConfig(name);
+      if (!project) {
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify({ error: `Project '${name}' not found` }),
+          }],
+          isError: true,
+        };
+      }
+      return {
+        content: [{
+          type: "text",
+          text: JSON.stringify(project, null, 2),
+        }],
+      };
+    }
+  );
+
+  // List make targets for a project
+  server.tool(
+    "swanson_list_targets",
+    "List available make targets (local.*) for a project",
+    {
+      projectName: z.string().describe("Project name"),
+    },
+    async ({ projectName }) => {
+      const project = getProjectConfig(projectName);
+      if (!project) {
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify({ error: `Project '${projectName}' not found` }),
+          }],
+          isError: true,
+        };
+      }
+
+      const targets = await parseMakefile(project.path);
+      return {
+        content: [{
+          type: "text",
+          text: JSON.stringify(targets, null, 2),
+        }],
+      };
+    }
+  );
+}


### PR DESCRIPTION
## Summary

- Adds MCP (Model Context Protocol) server to enable Claude Code integration
- Exposes 17 tools for managing projects, processes, GitHub issues/PRs, and git operations
- Includes comprehensive documentation

## Tools Added

**Projects:** `swanson_list_projects`, `swanson_get_project`, `swanson_list_targets`

**Processes:** `swanson_start_process`, `swanson_stop_process`, `swanson_stop_all`, `swanson_list_processes`, `swanson_get_process`, `swanson_get_logs`

**GitHub:** `swanson_gh_status`, `swanson_gh_issues`, `swanson_gh_issue`, `swanson_gh_prs`, `swanson_gh_stats`

**Git:** `swanson_git_status`, `swanson_git_pull`, `swanson_git_fetch`

## Usage

```bash
# Build and link
make local.link

# Register with Claude Code
claude mcp add --transport stdio swanson -- swanson-mcp
```

Then in Claude Code:
- "Start the dev server for funeralsni"
- "Show me the logs"
- "What GitHub issues are open?"

## Test plan

- [ ] Build project: `npm run build`
- [ ] Test MCP server: `echo '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' | node dist/mcp/index.js`
- [ ] Register with Claude Code and test tools
- [ ] Verify TUI still works: `make local.dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)